### PR TITLE
Color answer buttons

### DIFF
--- a/app/src/main/java/com/better/codingAlarm/alert/AlarmAlertFullScreen.kt
+++ b/app/src/main/java/com/better/codingAlarm/alert/AlarmAlertFullScreen.kt
@@ -165,8 +165,6 @@ class AlarmAlertFullScreen : FragmentActivity() {
         setButtonBehavior(R.id.alert_button_four, 3)
     }
 
-//
-
 
     private fun setButtonBehavior(buttonId: Int, answerIndex: Int) {
         val button = findViewById<Button>(buttonId)
@@ -217,86 +215,6 @@ class AlarmAlertFullScreen : FragmentActivity() {
         }
     }
 
-
-    private fun setButtonBehavior2(buttonId: Int, correctAnswerIndex: Int) {
-        findViewById<Button>(buttonId).run {
-            requestFocus()
-            setOnClickListener {
-                val questionCount = mAlarm?.data!!.questionCount
-                println("TEST -> Question count: $questionCount")
-                println("TEST -> Correct Answer: ${question?.correctAnswer}")
-                if (question?.correctAnswer == correctAnswerIndex) {
-                    println("TEST -> Selected Answer: $correctAnswerIndex")
-                    correctAnswerCount++
-                    println("TEST -> Now correct answer count is... $correctAnswerCount")
-
-                    if (mAlarm?.data!!.questionCount == correctAnswerCount) {
-                        mAlarm?.dismiss()
-                    }
-                } else {
-                    println("TEST -> Selected Answer: $correctAnswerIndex")
-                    println("TEST -> Correct Answer: ${question?.correctAnswer}")
-                }
-                question = QuestionList().getRandomQuestion(mAlarm?.data!!.questionType)
-                setQuestion()
-            }
-        }
-    }
-
-
-//    private fun updateLayout() {
-//        setContentView(R.layout.alert_fullscreen)
-//        setQuestion()
-//
-//        findViewById<Button>(R.id.alert_button_one).run {
-//            requestFocus()
-//            setOnClickListener {
-//                if (question?.correctAnswer == 0) {
-//                    println("correct!!")
-//                    mAlarm?.dismiss()
-//                } else {
-//                    question = QuestionList().getRandomQuestion(mAlarm?.data!!.questionType)
-//                    setQuestion()
-//                }
-//            }
-//        }
-//
-//        findViewById<Button>(R.id.alert_button_two).run {
-//            requestFocus()
-//            setOnClickListener {
-//                if (question?.correctAnswer == 1) {
-//                    mAlarm?.dismiss()
-//                } else {
-//                    question = QuestionList().getRandomQuestion(mAlarm?.data!!.questionType)
-//                    setQuestion()
-//                }
-//            }
-//        }
-//
-//        findViewById<Button>(R.id.alert_button_three).run {
-//            requestFocus()
-//            setOnClickListener {
-//                if (question?.correctAnswer == 2) {
-//                    mAlarm?.dismiss()
-//                } else {
-//                    question = QuestionList().getRandomQuestion(mAlarm?.data!!.questionType)
-//                    setQuestion()
-//                }
-//            }
-//        }
-//
-//        findViewById<Button>(R.id.alert_button_four).run {
-//            requestFocus()
-//            setOnClickListener {
-//                if (question?.correctAnswer == 3) {
-//                    mAlarm?.dismiss()
-//                } else {
-//                    question = QuestionList().getRandomQuestion(mAlarm?.data!!.questionType)
-//                    setQuestion()
-//                }
-//            }
-//        }
-//    }
 
     /**
      * Shows a time picker to pick the next snooze time. Mutes the sound for the first 10 seconds to

--- a/app/src/main/java/com/better/codingAlarm/alert/AlarmAlertFullScreen.kt
+++ b/app/src/main/java/com/better/codingAlarm/alert/AlarmAlertFullScreen.kt
@@ -21,9 +21,12 @@ import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.WindowManager
 import android.widget.Button
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.better.codingAlarm.R
 import com.better.codingAlarm.background.Event.Autosilenced
@@ -162,7 +165,60 @@ class AlarmAlertFullScreen : FragmentActivity() {
         setButtonBehavior(R.id.alert_button_four, 3)
     }
 
-    private fun setButtonBehavior(buttonId: Int, correctAnswerIndex: Int) {
+//
+
+
+    private fun setButtonBehavior(buttonId: Int, answerIndex: Int) {
+        val button = findViewById<Button>(buttonId)
+        val questionCount = mAlarm?.data!!.questionCount
+
+        val defaultButtonBackground = button.background // Store the default button background
+
+        button.setOnClickListener {
+            val isCorrect = question?.correctAnswer == answerIndex
+
+            if (isCorrect) {
+                correctAnswerCount++
+
+                if (questionCount == correctAnswerCount) {
+                    mAlarm?.dismiss()
+                }
+            }
+
+            button.setBackgroundResource(if (isCorrect) R.drawable.button_correct_background else R.drawable.button_incorrect_background)
+            button.setTextColor(ContextCompat.getColor(this, R.color.white))
+
+            // Highlight the correct answer button if the selected answer is incorrect
+            val correctButtonId = when (question?.correctAnswer) {
+                0 -> R.id.alert_button_one
+                1 -> R.id.alert_button_two
+                2 -> R.id.alert_button_three
+                3 -> R.id.alert_button_four
+                else -> -1
+            }
+
+            val correctButton = findViewById<Button>(correctButtonId)
+            correctButton.setBackgroundResource(R.drawable.button_correct_background)
+
+            // 텍스트 설정 및 1초 후에 다음 문제로 넘어가기
+            button.isEnabled = false
+            Handler(Looper.getMainLooper()).postDelayed({
+                // Question 다시 뽑아서 세팅
+                question = QuestionList().getRandomQuestion(mAlarm?.data!!.questionType)
+                setQuestion()
+
+                // 버튼 색 다시 default로 조정
+                button.background = defaultButtonBackground // Reset button background
+                correctButton.background = defaultButtonBackground // Reset correct answer button background
+                button.setTextColor(ContextCompat.getColor(this, R.color.dark_on_background))
+                correctButton.setTextColor(ContextCompat.getColor(this, R.color.dark_on_background))
+                button.isEnabled = true
+            }, 2000)
+        }
+    }
+
+
+    private fun setButtonBehavior2(buttonId: Int, correctAnswerIndex: Int) {
         findViewById<Button>(buttonId).run {
             requestFocus()
             setOnClickListener {
@@ -174,7 +230,7 @@ class AlarmAlertFullScreen : FragmentActivity() {
                     correctAnswerCount++
                     println("TEST -> Now correct answer count is... $correctAnswerCount")
 
-                    if (mAlarm?.data!!.questionCount == correctAnswerCount){
+                    if (mAlarm?.data!!.questionCount == correctAnswerCount) {
                         mAlarm?.dismiss()
                     }
                 } else {

--- a/app/src/main/java/com/better/codingAlarm/question/Question.kt
+++ b/app/src/main/java/com/better/codingAlarm/question/Question.kt
@@ -4,6 +4,6 @@ data class Question(
     val id: Int,
     val description: String,
     val choices: List<String>,
-    val correctAnswer: Int,
+    val correctAnswer: Int
 )
 

--- a/app/src/main/res/drawable/button_correct_background.xml
+++ b/app/src/main/res/drawable/button_correct_background.xml
@@ -1,0 +1,20 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/light_green" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+    <item android:state_selected="true"> <!-- This line highlights the correct answer -->
+        <shape android:shape="rectangle">
+            <solid android:color="@color/light_green" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/green" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/button_incorrect_background.xml
+++ b/app/src/main/res/drawable/button_incorrect_background.xml
@@ -1,0 +1,14 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/light_red" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/red" />
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout-v21/alert_fullscreen.xml
+++ b/app/src/main/res/layout-v21/alert_fullscreen.xml
@@ -93,7 +93,7 @@
                     android:layout_height="wrap_content"
                     android:text="5"
                     android:textSize="30sp"
-                    android:textStyle="bold"/>
+                    android:textStyle="bold" />
 
             </LinearLayout>
 
@@ -111,10 +111,10 @@
         android:layout_marginTop="10dp"
         android:layout_marginRight="40dp"
         android:layout_marginBottom="10dp"
-        android:text="One"
-        android:textColor="@color/dark_on_background"
         android:background="@color/blackish"
-        android:textAllCaps="false" />
+        android:text="One"
+        android:textAllCaps="false"
+        android:textColor="@color/dark_on_background" />
 
     <Button
         android:id="@+id/alert_button_two"
@@ -125,10 +125,10 @@
         android:layout_marginTop="10dp"
         android:layout_marginRight="40dp"
         android:layout_marginBottom="10dp"
-        android:text="Two"
-        android:textColor="@color/dark_on_background"
         android:background="@color/blackish"
-        android:textAllCaps="false" />
+        android:text="Two"
+        android:textAllCaps="false"
+        android:textColor="@color/dark_on_background" />
 
     <Button
         android:id="@+id/alert_button_three"
@@ -139,10 +139,10 @@
         android:layout_marginTop="10dp"
         android:layout_marginRight="40dp"
         android:layout_marginBottom="10dp"
-        android:text="Three"
-        android:textColor="@color/dark_on_background"
         android:background="@color/blackish"
-        android:textAllCaps="false" />
+        android:text="Three"
+        android:textAllCaps="false"
+        android:textColor="@color/dark_on_background" />
 
     <Button
         android:id="@+id/alert_button_four"
@@ -153,10 +153,10 @@
         android:layout_marginTop="10dp"
         android:layout_marginRight="40dp"
         android:layout_marginBottom="10dp"
-        android:text="Four"
-        android:textColor="@color/dark_on_background"
         android:background="@color/blackish"
-        android:textAllCaps="false" />
+        android:text="Four"
+        android:textAllCaps="false"
+        android:textColor="@color/dark_on_background" />
 
     <View
         android:layout_width="match_parent"
@@ -164,7 +164,6 @@
         android:layout_marginLeft="16dip"
         android:layout_marginRight="16dip"
         android:background="?android:attr/dividerHorizontal" />
-
 
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -28,4 +28,10 @@
     <color name="reactive_background">#2b323b</color>
     <color name="reactive_surface">#3f3d55</color>
     <color name="reactive_white">#ffffe8</color>
+
+    <color name="green">#4CAF50</color>
+    <color name="light_green">#8BC34A</color>
+    <color name="red">#F44336</color>
+    <color name="light_red">#FF5722</color>
+
 </resources>


### PR DESCRIPTION
- 오답 표시
    - 클릭한 버튼들에 색 추가
        - Correct
            - 초록
            - `res/drawable/button_correct_background.xml` 파일을 생성해서 정답 버튼 디자인에 대해 선언함
        - Wrong
            - 정답: 초록
            - 오답: 빨강
            - `res/drawable/button_incorrect_background.xml` 파일을 생성해서 오답 버튼 디자인에 대해 선언함
        - `res/values/colors.xml` 업데이트. 그린, 레드 등 버튼용 색깔을 선언해줌
  - 딜레이
        - 다음 추가 대신 3초동안 쉬었다가 다음 문제로 넘어가도록 설정

<img width="349" alt="Screenshot 2023-08-13 at 2 39 58 PM" src="https://github.com/g471000/coding-alarm-clock/assets/5580943/9858e5d3-6480-4267-ad0d-63304afc8f44">
<img width="348" alt="Screenshot 2023-08-13 at 2 40 19 PM" src="https://github.com/g471000/coding-alarm-clock/assets/5580943/01437031-f150-4530-a106-20ea33198164">
<img width="351" alt="Screenshot 2023-08-13 at 2 40 37 PM" src="https://github.com/g471000/coding-alarm-clock/assets/5580943/d48166f7-894a-4092-9f6a-a2597e633ba0">


