### PR TITLE
version code & name update 3.14.05 => 4.0.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,8 +81,8 @@ val acraEmail =
 android {
     compileSdk = 33
     defaultConfig {
-        versionCode = 31404
-        versionName = "3.14.04"
+        versionCode = 40000
+        versionName = "4.0.0"
         applicationId = "com.better.codingAlarm"
         minSdk = 16
         targetSdk = 33


### PR DESCRIPTION
version code 및 name 을 3.14.05 (기존 오픈소스의 버전)을 새롭게 시작하는 의미에서 4.0.0 으로 수정하였습니다.
1.0.0 부터 하지 않는 이유는, Google Play Console 에 이미 3.14.05 를 업로드 하였는데, 혹시나 보기 불편할 까봐 4 부터 시작하였습니다.